### PR TITLE
Fix IDOR vulnerabilities and marketplace quantity sync failure

### DIFF
--- a/app/inventoryApp/update_market.py
+++ b/app/inventoryApp/update_market.py
@@ -274,21 +274,25 @@ def update_inventory_price_quantity():
                     except Exception as e:
                         print(f"selling price calculation error for SKU {item.sku}: {e}")
                         continue
-                    # Check if the price and quantity of product on Ebay need to be updated
-                    if item.start_price != round(selling_price, 2) or item.quantity != db_item.quantity:
-                        # Check if the minimum quantity is lesser than supplier's quantity, use the minimum qauntity set by the user for the update, otherwise use the supplier's quantity for the update
-                        if user.maximum_quantity:
-                            if float(user.maximum_quantity) < float(db_item.quantity):
-                                quantity = user.maximum_quantity
-                            else:
-                                quantity = db_item.quantity
+                    # Determine quantity with max cap
+                    if user.maximum_quantity:
+                        if float(user.maximum_quantity) < float(db_item.quantity):
+                            quantity = user.maximum_quantity
+                        else:
+                            quantity = db_item.quantity
+                    else:
+                        quantity = db_item.quantity
 
+                    # Check if the price and quantity of product on Ebay need to be updated
+                    if (item.start_price != round(selling_price, 2) or item.quantity != quantity) and item.market_item_id:
                         response = update_items_quantity_or_price_on_ebay(user.user_id, item.market_item_id, round(selling_price, 2), quantity, user._id)
-                        if "Success" in response:
+                        if response and "Success" in response:
+                            # Only update local inventory after confirmed marketplace success
+                            inventory, created = InventoryModel.objects.update_or_create(id=item.id, defaults=dict(start_price=round(selling_price, 2), quantity=quantity, total_product_cost=db_item.total_product_cost, last_updated=timezone.now()))
                             item_to_save, created = MarketPlaceUpdateLog.objects.update_or_create(user_id=user.user_id, inventory_id=item.id, defaults=dict(market_name="Ebay", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {quantity} from vendor {item.vendor_name}"))
-                    # update inventory with the new price and quantity and log the update
-                    inventory, created = InventoryModel.objects.update_or_create(id=item.id, defaults=dict(start_price=round(selling_price, 2), quantity=f"eb:{quantity}|su:{db_item.quantity}", total_product_cost=db_item.total_product_cost, last_updated=timezone.now()))
-                    item_to_save, created = PriceQuantityUpdateLog.objects.update_or_create(user_id=user.user_id, inventory_id=item.id, defaults=dict(market_name="Ebay", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {db_item.quantity} from vendor {item.vendor_name}"))
+                            item_to_save, created = PriceQuantityUpdateLog.objects.update_or_create(user_id=user.user_id, inventory_id=item.id, defaults=dict(market_name="Ebay", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {quantity} from vendor {item.vendor_name}"))
+                        else:
+                            logger.error(f"eBay update FAILED for SKU {item.sku} (inventory_id={item.id}, market_item_id={item.market_item_id}). Response: {response}")
                 except Exception as e:
                     print(f"Product fails to update price and quantity: {e}")
                     continue
@@ -313,15 +317,25 @@ def update_inventory_price_quantity():
                                 selling_price = float(db_item.map)
                     except Exception as e:
                         print(f"MAP enforcement error for SKU {item.sku}: {e} — using base price")
-                    # Update the price and quantity of product on Woocommerce
-                    if item.start_price != round(selling_price, 2) or item.quantity != db_item.quantity:
-                        response = update_woocommerce_product_from_background(item.market_item_id, round(selling_price, 2), db_item.quantity, user.user_id)
-                        if response == "Success":
-                            item_to_save, created = MarketPlaceUpdateLog.objects.update_or_create(user_id=user.user_id, inventory_id=item.id, defaults=dict(market_name="Woocommerce", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {quantity} from vendor {item.vendor_name}"))
+                    # Determine quantity with max cap
+                    if user.maximum_quantity:
+                        if float(user.maximum_quantity) < float(db_item.quantity):
+                            quantity = user.maximum_quantity
+                        else:
+                            quantity = db_item.quantity
+                    else:
+                        quantity = db_item.quantity
 
-                    # update inventory with the new price and quantity and log the update
-                    inventory, created = InventoryModel.objects.update_or_create(id=item.id, defaults=dict(start_price=round(selling_price, 2), quantity=f"eb:{quantity}|su:{db_item.quantity}", total_product_cost=db_item.total_product_cost, last_updated=timezone.now()))
-                    item_to_save, created = PriceQuantityUpdateLog.objects.update_or_create(user_id=user.user_id, inventory_id=item.id, defaults=dict(market_name="Woocommerce", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {db_item.quantity} from vendor {item.vendor_name}"))
+                    # Update the price and quantity of product on Woocommerce
+                    if item.start_price != round(selling_price, 2) or item.quantity != quantity:
+                        response = update_woocommerce_product_from_background(item.market_item_id, round(selling_price, 2), quantity, user.user_id)
+                        if response == "Success":
+                            # Only update local inventory after confirmed marketplace success
+                            inventory, created = InventoryModel.objects.update_or_create(id=item.id, defaults=dict(start_price=round(selling_price, 2), quantity=quantity, total_product_cost=db_item.total_product_cost, last_updated=timezone.now()))
+                            item_to_save, created = MarketPlaceUpdateLog.objects.update_or_create(user_id=user.user_id, inventory_id=item.id, defaults=dict(market_name="Woocommerce", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {quantity} from vendor {item.vendor_name}"))
+                            item_to_save, created = PriceQuantityUpdateLog.objects.update_or_create(user_id=user.user_id, inventory_id=item.id, defaults=dict(market_name="Woocommerce", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {quantity} from vendor {item.vendor_name}"))
+                        else:
+                            logger.error(f"WooCommerce update FAILED for SKU {item.sku} (inventory_id={item.id}, market_item_id={item.market_item_id}). Response: {response}")
                 except Exception as e:
                     print(f"Product fails to update price and quantity on Woocommerce: {e}")
                     continue

--- a/app/inventoryApp/views.py
+++ b/app/inventoryApp/views.py
@@ -217,7 +217,7 @@ class General_operations:
                 if user.parent_id:
                     userid = user.parent_id
 
-            unmapped_item = InventoryModel.objects.all().filter(id=inventoryid).values()
+            unmapped_item = InventoryModel.objects.all().filter(id=inventoryid, user_id=userid).values()
             enrollment = Enrollment.objects.filter(user_id=userid)
             vendor_list = [vendor.identifier for vendor in enrollment]
             return JsonResponse({"item_details":list(unmapped_item), "vendor_list": list(dict.fromkeys(vendor_list))}, safe=False, status=status.HTTP_200_OK)
@@ -491,7 +491,7 @@ class MarketInventory:
         minv = MarketInventory()
         eb = Ebay()
         
-        product_info = get_object_or_404(InventoryModel, id=inventory_id)
+        product_info = get_object_or_404(InventoryModel, id=inventory_id, user_id=userid)
         serializer = InventoryModelUpdateSerializer(instance=product_info, data=request.data, partial=True)
         if serializer.is_valid():
             # get the serializer's data
@@ -676,7 +676,7 @@ class MarketInventory:
                 if user.parent_id:
                     userid = user.parent_id
 
-            inventory_item = InventoryModel.objects.all().filter(id=inventoryid).values()
+            inventory_item = InventoryModel.objects.all().filter(id=inventoryid, user_id=userid).values()
             return JsonResponse({"item_details":list(inventory_item)}, safe=False, status=status.HTTP_200_OK)
         except Exception as e:
             return Response(f"Failed to get items.", status=status.HTTP_400_BAD_REQUEST)
@@ -688,7 +688,13 @@ class MarketInventory:
     @api_view(['GET'])
     def get_saved_product_for_listing(request, inventoryid):
         try:
-            saved_item = InventoryModel.objects.all().filter(id=inventoryid).values()
+            userid = request.user.id
+            user = request.user
+            if user:
+                if user.parent_id:
+                    userid = user.parent_id
+
+            saved_item = InventoryModel.objects.all().filter(id=inventoryid, user_id=userid).values()
             return JsonResponse({"saved_items":list(saved_item)}, safe=False, status=status.HTTP_200_OK)
         except Exception as e:
             return Response(f"Failed to get items.", status=status.HTTP_400_BAD_REQUEST)
@@ -700,7 +706,13 @@ class MarketInventory:
     @api_view(['GET'])
     def delete_product_from_inventory(request, inventoryid):
         try:
-            invent_item = InventoryModel.objects.filter(id=inventoryid)
+            userid = request.user.id
+            user = request.user
+            if user:
+                if user.parent_id:
+                    userid = user.parent_id
+
+            invent_item = InventoryModel.objects.filter(id=inventoryid, user_id=userid)
             Generalproducttable.objects.filter(id=invent_item.values()[0].get('product_id')).update(active=False)
             invent_item.delete()
             return Response("Item deleted successfully", status=status.HTTP_200_OK)
@@ -723,7 +735,7 @@ class MarketInventory:
         
         access_token = eb.refresh_access_token(userid, "Ebay")
         try:
-            invent_item = InventoryModel.objects.get(id=inventoryid)
+            invent_item = InventoryModel.objects.get(id=inventoryid, user_id=userid)
             # end item on ebay listing
             url = "https://api.ebay.com/ws/api.dll"
             headers = {
@@ -810,7 +822,7 @@ class WooCommerceInventory:
                 consumer_secret = enrollment.wc_consumer_secret, 
                 version = "wc/v3"
             )
-            product_info = get_object_or_404(InventoryModel, id=inventory_id)
+            product_info = get_object_or_404(InventoryModel, id=inventory_id, user_id=userid)
             serializer = InventoryModelUpdateSerializer(instance=product_info, data=request.data, partial=True)
             if serializer.is_valid():
                 # get the serializer's data

--- a/app/marketplaceApp/util.py
+++ b/app/marketplaceApp/util.py
@@ -94,14 +94,17 @@ def complete_enrolment_price_update(userid, market_name):
                 except Exception as e:
                     print(f"item not found on product table: {e} with sku {item.sku}")
                     continue
-                # Check if the minimum quantity is lesser than supplier's quantity, use the minimum qauntity set by the user for the update, otherwise use the supplier's quantity for the update
+                # Determine quantity with max cap
                 if market_enrolled.maximum_quantity:
                     if float(market_enrolled.maximum_quantity) < float(db_item.quantity):
                         quantity = market_enrolled.maximum_quantity
                     else:
                         quantity = db_item.quantity
+                else:
+                    quantity = db_item.quantity
+
                 # Enforce MAP when wc_map_enforcement is enabled
-                if market_name == "Woocommerce": 
+                if market_name == "Woocommerce":
                     if market_enrolled.wc_map_enforcement==True and item.map==True:
                         try:
                             selling_price = max(round(selling_price, 2), float(item.map))
@@ -110,20 +113,25 @@ def complete_enrolment_price_update(userid, market_name):
                     # Update the price and quantity of product on Woocommerce
                     response = update_woocommerce_product_from_background(item.market_item_id, round(selling_price, 2), quantity, userid)
                     if response == "Success":
+                        inventory, created = InventoryModel.objects.update_or_create(user_id=userid, id=item.id, defaults=dict(start_price=round(selling_price, 2), quantity=quantity, total_product_cost=db_item.total_product_cost, last_updated=timezone.now()))
                         item_to_save, created = MarketPlaceUpdateLog.objects.update_or_create(user_id=userid, inventory_id=item.id, defaults=dict(market_name="Woocommerce", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {quantity} from vendor {item.vendor_name}"))
-                elif market_name == "Ebay": 
+                    else:
+                        logger.error(f"WooCommerce enrollment update FAILED for user {userid}, SKU {item.sku}. Response: {response}")
+
+                elif market_name == "Ebay":
                     if item.map:
                         try:
                             selling_price = max(round(selling_price, 2), float(item.map))
                         except (TypeError, ValueError) as map_err:
                             logger.warning(f"MAP enforcement skipped for SKU {item.sku}: {map_err}")
-                
+
                     # update the minimum quantity and new calculated price on Ebay for all items
                     response = complete_enrollment_quantity_price_update_on_ebay(userid, item.market_item_id, round(selling_price, 2), quantity, market_enrolled._id)
-                    if "Success" in response:
+                    if response and "Success" in response:
+                        inventory, created = InventoryModel.objects.update_or_create(user_id=userid, id=item.id, defaults=dict(start_price=round(selling_price, 2), quantity=quantity, total_product_cost=db_item.total_product_cost, last_updated=timezone.now()))
                         item_to_save, created = MarketPlaceUpdateLog.objects.update_or_create(user_id=userid, inventory_id=item.id, defaults=dict(market_name="Ebay", vendor_name=item.vendor_name, updated_sku=item.sku, log_description=f"Updated price to {round(selling_price, 2)} and quantity to {quantity} from vendor {item.vendor_name}"))
-                          
-                inventory, created = InventoryModel.objects.update_or_create(user_id=userid, id=item.id, defaults=dict(start_price=round(selling_price, 2), quantity=f"eb:{quantity}|su:{db_item.quantity}", total_product_cost=db_item.total_product_cost, last_updated=timezone.now()))
+                    else:
+                        logger.error(f"eBay enrollment update FAILED for user {userid}, SKU {item.sku}. Response: {response}")
         except Exception as e:
             print(f"Complete enrollment failed for user: {userid} with sku: {item.sku}. Error: {e}")
             continue


### PR DESCRIPTION
## Summary

### Commit 1: Fix IDOR vulnerabilities in inventory endpoints
- Added `user_id` filtering to 7 inventory endpoints that queried `InventoryModel` by primary key only, allowing any authenticated user to access/modify/delete other users' inventory items by enumerating IDs
- For endpoints without `userid` in the function signature (`get_saved_product_for_listing`, `delete_product_from_inventory`), `userid` is extracted from `request.user` with subaccount fallback

### Commit 2: Fix marketplace quantity sync failure
- **Root cause:** Local inventory quantity was updated unconditionally on every sync run, regardless of whether the eBay/WooCommerce API call succeeded. After one failed update, local quantity matched supplier (both 0), so the system never retried — leaving stale quantities on the marketplace permanently
- Moved local inventory update inside the API success check so failed updates retry automatically on the next run
- Stored quantity as a numeric value instead of diagnostic string (`"eb:50|su:0"`) which broke comparisons and display
- Added `else` fallback for `quantity` when `maximum_quantity` is not set (prevents `NameError`)
- Restored `market_item_id` guard on eBay path
- Added `None` response guard and `logger.error()` for failed API updates

## Files Changed
| File | Changes |
|------|---------|
| `app/inventoryApp/views.py` | 7 IDOR endpoint fixes — add `user_id` filtering |
| `app/inventoryApp/update_market.py` | Quantity sync fix — conditional inventory update for eBay and WooCommerce |
| `app/marketplaceApp/util.py` | Quantity sync fix — conditional inventory update for enrollment price update |

## Test plan
- [ ] Verify authenticated user can access their own inventory items normally
- [ ] Verify authenticated user cannot access another user's inventory item by ID
- [ ] Verify subaccount users can still access parent account inventory
- [ ] Verify quantity updates to eBay: on API success, local quantity updates; on API failure, local quantity is preserved and retried next run
- [ ] Verify quantity updates to WooCommerce: same success/failure behavior
- [ ] Verify items without `market_item_id` are skipped (no unnecessary API calls)
- [ ] Verify users without `maximum_quantity` set do not crash (no `NameError`)
- [ ] Check logs for `eBay update FAILED` / `WooCommerce update FAILED` entries on failures
- [ ] Verify quantity field stores numeric values, not strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)